### PR TITLE
Allow ModTek to override the manifest for users with FlashPoint

### DIFF
--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -24,6 +24,9 @@ namespace ModTek
     {
         public static VersionManifest cachedManifest = null;
 
+        // Lookup for all manifest entries that modtek adds
+        public static Dictionary<string, VersionManifestEntry> modtekOverrides = null;
+
         private static bool hasLoadedMods; //defaults to false
 
         // file/directory names
@@ -1005,7 +1008,24 @@ namespace ModTek
 
             // Cache the completed manifest
             ModTek.cachedManifest = manifest;
-            
+
+            try
+            {
+                if (manifest != null && ModTek.modEntries != null)
+                {
+                    ModTek.modtekOverrides = manifest.Entries.Where(e => ModTek.modEntries.Any(m => e.Id == m.Id))
+                        // ToDictionary expects distinct keys, so take the last entry of each Id
+                        .GroupBy(ks => ks.Id)
+                        .Select(v => v.Last())
+                        .ToDictionary(ks => ks.Id);
+                }
+                Logger.Log("Built {0} modtek overrides", ModTek.modtekOverrides.Count());
+            }
+            catch (Exception e)
+            {
+                Logger.Log("Failed to build overrides {0}", e);
+            }
+
             yield break;
         }
     }

--- a/ModTek/Patches.cs
+++ b/ModTek/Patches.cs
@@ -153,6 +153,21 @@ namespace ModTek
         }
     }
 
+    // Flashpoint (and presumably all future DLC) modify the manifest later
+    // Rather than trying to maintain a valid manifest, it's easier to just
+    //   intercept the asset lookups, and provide a modtek asset if necessary
+    [HarmonyPatch(typeof(BattleTechResourceLocator), "EntryByID")]
+    public static class BattleTechResourceLocator_EntryByID_Patch
+    {
+        public static void Postfix(string id, ref VersionManifestEntry __result)
+        {
+            if (ModTek.modtekOverrides != null && ModTek.modtekOverrides.TryGetValue(id, out var entry))
+            {
+                __result = entry;
+            }
+        }
+    }
+
     // This will disable activateAfterInit from functioning for the Start() on the "Main" game object which activates the BattleTechGame object
     // This stops the main game object from loading immediately -- so work can be done beforehand
     [HarmonyPatch(typeof(ActivateAfterInit), "Start")]


### PR DESCRIPTION
There are a couple of places where 1.3 modifies the manifest after the ModTek startup.  This causes it to basically ignore all modtek mods.

I figured it was easier to just patch the lookup, rather than try to figure out all the places where it gets touched.

Thoughts?