### PR TITLE
[Performance] Don't open a new file handle for every log message

### DIFF
--- a/ModTek/Logger.cs
+++ b/ModTek/Logger.cs
@@ -18,6 +18,14 @@ namespace ModTek
             return LogStream;
         }
 
+        internal static void CloseStream()
+        {
+            if (LogStream == null)
+                return;
+            LogStream.Dispose();
+            LogStream = null;
+        }
+
         [StringFormatMethod("message")]
         internal static void Log(string message, params object[] formatObjects)
         {
@@ -39,5 +47,7 @@ namespace ModTek
 
             stream.WriteLine(DateTime.Now.ToLongTimeString() + " - " + message, formatObjects);
         }
+
+
     }
 }

--- a/ModTek/Logger.cs
+++ b/ModTek/Logger.cs
@@ -9,24 +9,35 @@ namespace ModTek
         // logging
         internal static string LogPath { get; set; }
 
+        internal static StreamWriter LogStream;
+
+        internal static StreamWriter GetStream()
+        {
+            if (LogStream == null && !string.IsNullOrEmpty(LogPath))
+                LogStream = File.AppendText(LogPath);
+            return LogStream;
+        }
+
         [StringFormatMethod("message")]
         internal static void Log(string message, params object[] formatObjects)
         {
             if (string.IsNullOrEmpty(LogPath)) return;
-            using (var logWriter = File.AppendText(LogPath))
-            {
-                logWriter.WriteLine(message, formatObjects);
-            }
+
+            var stream = GetStream();
+            if (stream == null) return;
+            
+            stream.WriteLine(message, formatObjects);
         }
 
         [StringFormatMethod("message")]
         internal static void LogWithDate(string message, params object[] formatObjects)
         {
             if (string.IsNullOrEmpty(LogPath)) return;
-            using (var logWriter = File.AppendText(LogPath))
-            {
-                logWriter.WriteLine(DateTime.Now.ToLongTimeString() + " - " + message, formatObjects);
-            }
+
+            var stream = GetStream();
+            if (stream == null) return;
+
+            stream.WriteLine(DateTime.Now.ToLongTimeString() + " - " + message, formatObjects);
         }
     }
 }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -1026,6 +1026,8 @@ namespace ModTek
                 Logger.Log("Failed to build overrides {0}", e);
             }
 
+            Logger.CloseStream();
+
             yield break;
         }
     }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -142,6 +142,7 @@ namespace ModTek
             else
             {
                 Log("Failed to load progress bar.  Skipping mod loading completely.");
+                Logger.CloseStream();
             }
 
             stopwatch.Stop();


### PR DESCRIPTION
After a performance review of ModTek, approximately 2/3rds of the time is spent writing to the log.

Each log message was opening a new stream, and writing a single message. This PR simply opens a single stream for the entire duration of modtek.

Here are the modtek times for an already cached RogueTech:
```
              (m:ss)
Logging      : 2:54
No logging   : 1:04
Single handle: 1:36  ; this PR
```