### PR TITLE
Only trigger game load after modtek screen has closed

### DIFF
--- a/ModTek/ProgressPanel.cs
+++ b/ModTek/ProgressPanel.cs
@@ -84,6 +84,12 @@ namespace ModTek
                     Logger.Log(string.Format("Exception during ModTek: RunWorkFunc {0}", e));
                 }
 
+                // Wait two frames to ensure that modtek screen is destroyed and a render has occurred.
+                yield return null;
+                yield return null;
+
+                TriggerGameLoading();
+
                 yield break;
             }
         }
@@ -159,7 +165,6 @@ namespace ModTek
                     {
                         ProgressBarAssetBundle.Unload(true);
                         Destroy(canvasGO);
-                        TriggerGameLoading();
                     });
                 }
             }


### PR DESCRIPTION
I've seen a few support issues come up of "ModTek is hanging on Done screen"

This hang is a vanilla hang, but is being attributed to ModTek. It's a bad look for us.

This patch waits till the ModTek screen has closed before initializing the vanilla game.